### PR TITLE
Fix large binary string read and add regression test

### DIFF
--- a/include/cereal/archives/binary.hpp
+++ b/include/cereal/archives/binary.hpp
@@ -99,10 +99,22 @@ namespace cereal
       //! Reads size bytes of data from the input stream
       void loadBinary( void * const data, std::streamsize size )
       {
-        auto const readSize = itsStream.rdbuf()->sgetn( reinterpret_cast<char*>( data ), size );
+        auto totalRead = std::streamsize{0};
+        auto * const basePtr = reinterpret_cast<char*>( data );
 
-        if(readSize != size)
-          throw Exception("Failed to read " + std::to_string(size) + " bytes from input stream! Read " + std::to_string(readSize));
+        while(totalRead < size)
+        {
+          itsStream.read( basePtr + totalRead, size - totalRead );
+          auto const readSize = itsStream.gcount();
+
+          if(readSize == 0)
+            break;
+
+          totalRead += readSize;
+        }
+
+        if(totalRead != size)
+          throw Exception("Failed to read " + std::to_string(size) + " bytes from input stream! Read " + std::to_string(totalRead));
       }
 
     private:

--- a/include/cereal/archives/portable_binary.hpp
+++ b/include/cereal/archives/portable_binary.hpp
@@ -238,11 +238,22 @@ namespace cereal
       template <std::streamsize DataSize> inline
       void loadBinary( void * const data, std::streamsize size )
       {
-        // load data
-        auto const readSize = itsStream.rdbuf()->sgetn( reinterpret_cast<char*>( data ), size );
+        auto totalRead = std::streamsize{0};
+        auto * const basePtr = reinterpret_cast<char*>( data );
 
-        if(readSize != size)
-          throw Exception("Failed to read " + std::to_string(size) + " bytes from input stream! Read " + std::to_string(readSize));
+        while(totalRead < size)
+        {
+          itsStream.read( basePtr + totalRead, size - totalRead );
+          auto const readSize = itsStream.gcount();
+
+          if(readSize == 0)
+            break;
+
+          totalRead += readSize;
+        }
+
+        if(totalRead != size)
+          throw Exception("Failed to read " + std::to_string(size) + " bytes from input stream! Read " + std::to_string(totalRead));
 
         // flip bits if needed
         if( itsConvertEndianness )

--- a/unittests/basic_string.cpp
+++ b/unittests/basic_string.cpp
@@ -39,6 +39,16 @@ TEST_CASE("portable_binary_string")
   test_string_all<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>();
 }
 
+TEST_CASE("binary_string_large")
+{
+  test_string_large<cereal::BinaryInputArchive, cereal::BinaryOutputArchive>();
+}
+
+TEST_CASE("portable_binary_string_large")
+{
+  test_string_large<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>();
+}
+
 TEST_CASE("xml_string_basic")
 {
   test_string_basic<cereal::XMLInputArchive, cereal::XMLOutputArchive>();

--- a/unittests/basic_string.hpp
+++ b/unittests/basic_string.hpp
@@ -111,4 +111,27 @@ void test_string_all()
   }
 }
 
+template <class IArchive, class OArchive> inline
+void test_string_large()
+{
+  std::basic_string<char> o_string(10 * 1024 * 1024, '\0');
+
+  std::ostringstream os;
+  {
+    OArchive oar(os);
+    oar(o_string);
+  }
+
+  std::basic_string<char> i_string;
+
+  std::istringstream is(os.str());
+  {
+    IArchive iar(is);
+    iar(i_string);
+  }
+
+  CHECK_EQ(i_string.size(), o_string.size());
+  CHECK_EQ(i_string, o_string);
+}
+
 #endif // CEREAL_TEST_BASIC_STRING_H_


### PR DESCRIPTION
## Summary
- Read binary data in a loop to handle partial reads on some platforms
- Mirror robust read logic in portable binary archive
- Add regression tests for deserializing large strings

## Testing
- `cmake --build . --target test_basic_string`
- `./unittests/test_basic_string`
