### PR TITLE
Support free-function load_and_construct

### DIFF
--- a/include/cereal/details/traits.hpp
+++ b/include/cereal/details/traits.hpp
@@ -907,23 +907,35 @@ namespace cereal
     //! Creates a test for whether a non-member load_and_construct specialization exists
     /*! This creates a class derived from std::integral_constant that will be true if
         the type has the proper non-member function for the given archive. */
-    #define CEREAL_MAKE_HAS_NON_MEMBER_LOAD_AND_CONSTRUCT_TEST(test_name, versioned)                                            \
-    namespace detail                                                                                                            \
-    {                                                                                                                           \
-      template <class T, class A>                                                                                               \
-      struct has_non_member_##test_name##_impl                                                                                  \
-      {                                                                                                                         \
-        template <class TT, class AA>                                                                                           \
-        static auto test(int) -> decltype( LoadAndConstruct<TT>::load_and_construct(                                            \
-                                           std::declval<AA&>(), std::declval< ::cereal::construct<TT>&>() versioned ), yes());  \
-        template <class, class>                                                                                                 \
-        static no test( ... );                                                                                                  \
-        static const bool value = std::is_same<decltype( test<T, A>( 0 ) ), yes>::value;                                        \
-      };                                                                                                                        \
-    } /* end namespace detail */                                                                                                \
-    template <class T, class A>                                                                                                 \
-    struct has_non_member_##test_name :                                                                                         \
-      std::integral_constant<bool, detail::has_non_member_##test_name##_impl<typename std::remove_const<T>::type, A>::value> {};
+    #define CEREAL_MAKE_HAS_NON_MEMBER_LOAD_AND_CONSTRUCT_TEST(test_name, versioned) \
+    namespace detail \
+    { \
+      template <class T, class A> \
+      struct has_non_member_##test_name##_struct_impl \
+      { \
+        template <class TT, class AA> \
+        static auto test(int) -> decltype( LoadAndConstruct<TT>::load_and_construct( \
+                                           std::declval<AA&>(), std::declval< ::cereal::construct<TT>&>() versioned ), yes()); \
+        template <class, class> \
+        static no test( ... ); \
+        static const bool value = std::is_same<decltype( test<T, A>( 0 ) ), yes>::value; \
+      }; \
+      template <class T, class A> \
+      struct has_non_member_##test_name##_free_impl \
+      { \
+        template <class TT, class AA> \
+        static auto test(int) -> decltype( load_and_construct( \
+                                           std::declval<AA&>(), std::declval< ::cereal::construct<TT>&>() versioned ), yes()); \
+        template <class, class> \
+        static no test( ... ); \
+        static const bool value = std::is_same<decltype( test<T, A>( 0 ) ), yes>::value; \
+      }; \
+    } /* end namespace detail */ \
+    template <class T, class A> \
+    struct has_non_member_##test_name : \
+      std::integral_constant<bool, \
+        detail::has_non_member_##test_name##_struct_impl<typename std::remove_const<T>::type, A>::value || \
+        detail::has_non_member_##test_name##_free_impl<typename std::remove_const<T>::type, A>::value> {};
 
     // ######################################################################
     //! Non member load and construct check
@@ -1326,6 +1338,22 @@ namespace cereal
       std::is_base_of<TextArchive, detail::decay_archive<A>>::value>
     { };
   } // namespace traits
+// Wrapper to invoke either a non-member LoadAndConstruct struct specialization or
+// a free function discovered via ADL
+template <class T, class Archive>
+inline auto load_and_construct( Archive & ar, construct<T> & construct ) ->
+  decltype( LoadAndConstruct<T>::load_and_construct( ar, construct ), void() )
+{
+  LoadAndConstruct<T>::load_and_construct( ar, construct );
+}
+
+template <class T, class Archive>
+inline auto load_and_construct( Archive & ar, construct<T> & construct, const std::uint32_t version ) ->
+  decltype( LoadAndConstruct<T>::load_and_construct( ar, construct, version ), void() )
+{
+  LoadAndConstruct<T>::load_and_construct( ar, construct, version );
+}
+
 
   // ######################################################################
   namespace detail
@@ -1391,7 +1419,8 @@ namespace cereal
     {
       static void load_andor_construct( A & ar, construct<T> & construct )
       {
-        LoadAndConstruct<T>::load_and_construct( ar, construct );
+        using ::cereal::load_and_construct;
+        load_and_construct( ar, construct );
       }
     };
 
@@ -1402,7 +1431,8 @@ namespace cereal
       static void load_andor_construct( A & ar, construct<T> & construct )
       {
         const auto version = ar.template loadClassVersion<T>();
-        LoadAndConstruct<T>::load_and_construct( ar, construct, version );
+        using ::cereal::load_and_construct;
+        load_and_construct( ar, construct, version );
       }
     };
   } // namespace detail

--- a/unittests/load_construct.hpp
+++ b/unittests/load_construct.hpp
@@ -190,6 +190,37 @@ std::ostream& operator<<(std::ostream& os, ThreeLA const & s)
   return os;
 }
 
+struct FourLA
+{
+  FourLA( int xx ) : x( xx ) {}
+
+  int x;
+
+  template <class Archive>
+  void serialize( Archive & ar )
+  { ar( x ); }
+
+  bool operator==( FourLA const & other ) const
+  { return x == other.x; }
+};
+
+std::ostream& operator<<(std::ostream& os, FourLA const & s)
+{
+  os << "[" << s.x << "]";
+  return os;
+}
+
+namespace cereal
+{
+  template <class Archive>
+  void load_and_construct( Archive & ar, cereal::construct<FourLA> & construct )
+  {
+    int xx;
+    ar( xx );
+    construct( xx );
+  }
+}
+
 template <class IArchive, class OArchive>
 void test_memory_load_construct()
 {
@@ -203,6 +234,7 @@ void test_memory_load_construct()
     std::unique_ptr<OneLA> o_unique1( new OneLA( random_value<int>(gen) ) );
     std::unique_ptr<TwoLA> o_unique2( new TwoLA( random_value<int>(gen) ) );
     auto o_shared3 = std::make_shared<ThreeLA>( random_value<int>(gen) );
+    auto o_shared4 = std::make_shared<FourLA>( random_value<int>(gen) );
     auto o_shared1v = std::make_shared<OneLAVersioned>( random_value<int>(gen) );
     auto o_shared2v = std::make_shared<TwoLAVersioned>( random_value<int>(gen) );
 
@@ -211,6 +243,7 @@ void test_memory_load_construct()
     std::unique_ptr<const OneLA> o_constUnique1( new OneLA( random_value<int>(gen) ) );
     std::unique_ptr<const TwoLA> o_constUnique2( new TwoLA( random_value<int>(gen) ) );
     auto o_constShared3 = std::make_shared<const ThreeLA>( random_value<int>(gen) );
+    auto o_constShared4 = std::make_shared<const FourLA>( random_value<int>(gen) );
     auto o_constShared1v = std::make_shared<const OneLAVersioned>( random_value<int>(gen) );
     auto o_constShared2v = std::make_shared<const TwoLAVersioned>( random_value<int>(gen) );
 
@@ -223,6 +256,7 @@ void test_memory_load_construct()
       oar( o_unique1 );
       oar( o_unique2 );
       oar( o_shared3 );
+      oar( o_shared4 );
       oar( o_shared1v );
       oar( o_shared2v );
       oar( o_constShared1 );
@@ -230,6 +264,7 @@ void test_memory_load_construct()
       oar( o_constUnique1 );
       oar( o_constUnique2 );
       oar( o_constShared3 );
+      oar( o_constShared4 );
       oar( o_constShared1v );
       oar( o_constShared2v );
     }
@@ -242,6 +277,7 @@ void test_memory_load_construct()
     decltype(o_unique1) i_unique1;
     decltype(o_unique2) i_unique2;
     decltype(o_shared3) i_shared3;
+    decltype(o_shared4) i_shared4;
     decltype(o_shared1v) i_shared1v;
     decltype(o_shared2v) i_shared2v;
     decltype(o_constShared1) i_constShared1;
@@ -249,6 +285,7 @@ void test_memory_load_construct()
     decltype(o_constUnique1) i_constUnique1;
     decltype(o_constUnique2) i_constUnique2;
     decltype(o_constShared3) i_constShared3;
+    decltype(o_constShared4) i_constShared4;
     decltype(o_constShared1v) i_constShared1v;
     decltype(o_constShared2v) i_constShared2v;
 
@@ -261,6 +298,7 @@ void test_memory_load_construct()
       iar( i_unique1 );
       iar( i_unique2 );
       iar( i_shared3 );
+      iar( i_shared4 );
       iar( i_shared1v );
       iar( i_shared2v );
       iar( i_constShared1 );
@@ -268,6 +306,7 @@ void test_memory_load_construct()
       iar( i_constUnique1 );
       iar( i_constUnique2 );
       iar( i_constShared3 );
+      iar( i_constShared4 );
       iar( i_constShared1v );
       iar( i_constShared2v );
     }
@@ -277,6 +316,7 @@ void test_memory_load_construct()
     CHECK_EQ( *o_unique1, *i_unique1 );
     CHECK_EQ( *o_unique2, *i_unique2 );
     CHECK_EQ( *o_shared3, *i_shared3 );
+    CHECK_EQ( *o_shared4, *i_shared4 );
     CHECK_EQ( *o_shared1v, *i_shared1v );
     CHECK_EQ(i_shared1v->v, 13u);
     CHECK_EQ( *o_shared2v, *i_shared2v );
@@ -290,6 +330,7 @@ void test_memory_load_construct()
     CHECK_EQ( *o_constUnique1, *i_constUnique1 );
     CHECK_EQ( *o_constUnique2, *i_constUnique2 );
     CHECK_EQ( *o_constShared3, *i_constShared3 );
+    CHECK_EQ( *o_constShared4, *i_constShared4 );
     CHECK_EQ( *o_constShared1v, *i_constShared1v );
     CHECK_EQ(i_constShared1v->v, 13u);
     CHECK_EQ( *o_constShared2v, *i_constShared2v );


### PR DESCRIPTION
## Summary
- extend traits to detect free `load_and_construct` functions in addition to `LoadAndConstruct` specializations
- add wrapper to call free or struct-based load_and_construct
- test free-function load_and_construct across archives

## Testing
- `cmake --build . --target test_load_construct`
- `./unittests/test_load_construct`


------
https://chatgpt.com/codex/tasks/task_e_68b1777fa228832088aec6aa9cacd1cd