### PR TITLE
Add AGENTS.md with cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Agents
+
+## Cursor Cloud specific instructions
+
+This is **cereal** — a header-only C++11 serialization library. There are no runtime services, databases, or containers.
+
+### Build & Test
+
+The build directory is at `/workspace/build`. After the update script runs, it is already built and ready.
+
+```bash
+cd /workspace/build
+ctest --output-on-failure        # run all 40 unit tests
+./sandbox/sandbox                # binary/XML/portable-binary demo
+./sandbox/sandbox_json           # JSON archive demo
+```
+
+### Key Gotchas
+
+- **Default `c++` points to clang++** which cannot link (`-lstdc++` not found). The update script forces `g++` via `update-alternatives`. If you hit linker errors about `-lstdc++`, re-run `sudo update-alternatives --set c++ /usr/bin/g++`.
+- **GCC 13 `-Wdangling-reference`** fires false positives in `polymorphic_impl.hpp`. The build uses `-DWITH_WERROR=OFF` to avoid breaking on these warnings. Do not re-enable `-Werror` unless the upstream code is patched.
+- **Portability tests** (32-bit) are skipped because `multilib` packages are not installed and `-m32` is unsupported.
+- **Boost performance comparison** is skipped (`-DSKIP_PERFORMANCE_COMPARISON=ON`) because `libboost-serialization-dev` is not installed.
+- **Documentation** build is disabled (`-DBUILD_DOC=OFF`) because Doxygen is not installed.
+
+### Reconfiguring
+
+If you need to reconfigure (e.g. to change the C++ standard):
+
+```bash
+rm -rf /workspace/build && mkdir /workspace/build && cd /workspace/build
+cmake -DSKIP_PORTABILITY_TEST=ON -DSKIP_PERFORMANCE_COMPARISON=ON -DBUILD_DOC=OFF \
+      -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DWITH_WERROR=OFF ..
+make -j$(nproc)
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud-specific development instructions for the cereal C++ serialization library.

## What this adds

- Build & test quick-reference commands
- Key gotchas for the cloud VM environment:
  - Default `c++` linker issue (clang++ cannot find `-lstdc++`; workaround: use `g++` via `update-alternatives`)
  - GCC 13 false-positive `-Wdangling-reference` warnings requiring `-DWITH_WERROR=OFF`
  - Skipped optional features (portability tests, Boost comparison, Doxygen docs)
- Reconfiguration instructions

## Verification

All 40 unit tests pass, sandbox examples (binary, XML, JSON, portable-binary) run successfully.

[test_results.log](https://cursor.com/agents/bc-f60ec4d8-5a2a-4e23-b6f0-4da1e3ba76d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_results.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f60ec4d8-5a2a-4e23-b6f0-4da1e3ba76d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f60ec4d8-5a2a-4e23-b6f0-4da1e3ba76d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

