### PR TITLE
Add test for external load_and_construct with Binary archive (#839)

### DIFF
--- a/unittests/load_construct_ext_binary.cpp
+++ b/unittests/load_construct_ext_binary.cpp
@@ -1,0 +1,56 @@
+/*
+  Copyright (c) 2014, Randolph Voorhies, Shane Grant
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of the copyright holder nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "load_construct_ext_binary.hpp"
+
+// Issue #839: External load_and_construct does not work with Binary archive
+// These tests verify that external LoadAndConstruct specializations are
+// correctly invoked for all archive types, including BinaryInputArchive.
+
+TEST_SUITE_BEGIN("load_construct_ext_binary");
+
+TEST_CASE("binary_external_load_and_construct")
+{
+  test_external_load_and_construct_binary<cereal::BinaryInputArchive, cereal::BinaryOutputArchive>();
+}
+
+TEST_CASE("portable_binary_external_load_and_construct")
+{
+  test_external_load_and_construct_binary<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>();
+}
+
+TEST_CASE("xml_external_load_and_construct")
+{
+  test_external_load_and_construct_binary<cereal::XMLInputArchive, cereal::XMLOutputArchive>();
+}
+
+TEST_CASE("json_external_load_and_construct")
+{
+  test_external_load_and_construct_binary<cereal::JSONInputArchive, cereal::JSONOutputArchive>();
+}
+
+TEST_SUITE_END();

--- a/unittests/load_construct_ext_binary.hpp
+++ b/unittests/load_construct_ext_binary.hpp
@@ -1,0 +1,206 @@
+/*
+  Copyright (c) 2014, Randolph Voorhies, Shane Grant
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+      * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+      * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+      * Neither the name of the copyright holder nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#ifndef CEREAL_TEST_LOAD_CONSTRUCT_EXT_BINARY_H_
+#define CEREAL_TEST_LOAD_CONSTRUCT_EXT_BINARY_H_
+#include "common.hpp"
+
+// Issue #839: External load_and_construct does not work with Binary archive
+//
+// This test verifies that external LoadAndConstruct specializations work
+// correctly with BinaryInputArchive, just as they do with XML, JSON, and
+// PortableBinary archives.
+
+// A type with no default constructor and only an external save function.
+// Loading is exclusively through external LoadAndConstruct.
+struct ExtLacSaveOnly
+{
+  ExtLacSaveOnly( int xx, double yy ) : x( xx ), y( yy ) {}
+
+  int x;
+  double y;
+
+  bool operator==( ExtLacSaveOnly const & other ) const
+  { return x == other.x && std::abs(y - other.y) < 1e-10; }
+};
+
+std::ostream& operator<<(std::ostream& os, ExtLacSaveOnly const & s)
+{
+  os << "[" << s.x << ", " << s.y << "]";
+  return os;
+}
+
+template <class Archive>
+void save( Archive & ar, ExtLacSaveOnly const & obj )
+{
+  ar( obj.x, obj.y );
+}
+
+namespace cereal
+{
+  template <>
+  struct LoadAndConstruct<ExtLacSaveOnly>
+  {
+    template <class Archive>
+    static void load_and_construct( Archive & ar, cereal::construct<ExtLacSaveOnly> & construct )
+    {
+      int xx;
+      double yy;
+      ar( xx, yy );
+      construct( xx, yy );
+    }
+  };
+}
+
+// A type with no default constructor, member serialize, and external LoadAndConstruct.
+// This tests the case where the type has a serialize function but the external
+// LoadAndConstruct should still be used when loading through pointers.
+struct ExtLacWithSerialize
+{
+  ExtLacWithSerialize( int xx ) : x( xx ) {}
+
+  int x;
+
+  template <class Archive>
+  void serialize( Archive & ar )
+  { ar( x ); }
+
+  bool operator==( ExtLacWithSerialize const & other ) const
+  { return x == other.x; }
+
+private:
+  ExtLacWithSerialize() : x( 0 ) {}
+  friend class cereal::access;
+};
+
+std::ostream& operator<<(std::ostream& os, ExtLacWithSerialize const & s)
+{
+  os << "[" << s.x << "]";
+  return os;
+}
+
+namespace cereal
+{
+  template <>
+  struct LoadAndConstruct<ExtLacWithSerialize>
+  {
+    template <class Archive>
+    static void load_and_construct( Archive & ar, cereal::construct<ExtLacWithSerialize> & construct )
+    {
+      int xx;
+      ar( xx );
+      construct( xx );
+    }
+  };
+}
+
+// A type with no default constructor, external save/LoadAndConstruct, and
+// multiple data members to verify correct binary stream positioning.
+struct ExtLacMultiField
+{
+  ExtLacMultiField( int a, float b, std::string c ) : alpha( a ), beta( b ), gamma( std::move(c) ) {}
+
+  int alpha;
+  float beta;
+  std::string gamma;
+
+  bool operator==( ExtLacMultiField const & other ) const
+  { return alpha == other.alpha && std::abs(beta - other.beta) < 1e-5f && gamma == other.gamma; }
+};
+
+std::ostream& operator<<(std::ostream& os, ExtLacMultiField const & s)
+{
+  os << "[" << s.alpha << ", " << s.beta << ", " << s.gamma << "]";
+  return os;
+}
+
+template <class Archive>
+void save( Archive & ar, ExtLacMultiField const & obj )
+{
+  ar( obj.alpha, obj.beta, obj.gamma );
+}
+
+namespace cereal
+{
+  template <>
+  struct LoadAndConstruct<ExtLacMultiField>
+  {
+    template <class Archive>
+    static void load_and_construct( Archive & ar, cereal::construct<ExtLacMultiField> & construct )
+    {
+      int a;
+      float b;
+      std::string c;
+      ar( a, b, c );
+      construct( a, b, std::move(c) );
+    }
+  };
+}
+
+template <class IArchive, class OArchive>
+void test_external_load_and_construct_binary()
+{
+  std::random_device rd;
+  std::mt19937 gen(rd());
+
+  for(int ii=0; ii<100; ++ii)
+  {
+    auto o_shared1 = std::make_shared<ExtLacSaveOnly>( random_value<int>(gen), random_value<double>(gen) );
+    std::unique_ptr<ExtLacSaveOnly> o_unique1( new ExtLacSaveOnly( random_value<int>(gen), random_value<double>(gen) ) );
+    auto o_shared2 = std::make_shared<ExtLacWithSerialize>( random_value<int>(gen) );
+    std::unique_ptr<ExtLacWithSerialize> o_unique2( new ExtLacWithSerialize( random_value<int>(gen) ) );
+    auto o_shared3 = std::make_shared<ExtLacMultiField>( random_value<int>(gen), random_value<float>(gen), "test_str" );
+    std::unique_ptr<ExtLacMultiField> o_unique3( new ExtLacMultiField( random_value<int>(gen), random_value<float>(gen), "hello" ) );
+
+    std::ostringstream os;
+    {
+      OArchive oar(os);
+      oar( o_shared1, o_unique1, o_shared2, o_unique2, o_shared3, o_unique3 );
+    }
+
+    decltype(o_shared1) i_shared1;
+    decltype(o_unique1) i_unique1;
+    decltype(o_shared2) i_shared2;
+    decltype(o_unique2) i_unique2;
+    decltype(o_shared3) i_shared3;
+    decltype(o_unique3) i_unique3;
+
+    std::istringstream is(os.str());
+    {
+      IArchive iar(is);
+      iar( i_shared1, i_unique1, i_shared2, i_unique2, i_shared3, i_unique3 );
+    }
+
+    CHECK_EQ( *o_shared1, *i_shared1 );
+    CHECK_EQ( *o_unique1, *i_unique1 );
+    CHECK_EQ( *o_shared2, *i_shared2 );
+    CHECK_EQ( *o_unique2, *i_unique2 );
+    CHECK_EQ( *o_shared3, *i_shared3 );
+    CHECK_EQ( *o_unique3, *i_unique3 );
+  }
+}
+
+#endif // CEREAL_TEST_LOAD_CONSTRUCT_EXT_BINARY_H_


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses [USCiLab/cereal#839](https://github.com/USCiLab/cereal/issues/839) — "External load_and_construct does not work with Binary archive."

## Investigation

After extensive analysis of the library internals and numerous reproduction attempts, **external `LoadAndConstruct` specializations work correctly with `BinaryInputArchive`** in the current codebase. The mechanism correctly:

1. Detects `has_non_member_load_and_construct<T, BinaryInputArchive>` via SFINAE
2. Selects the `load_and_construct` overload for `PtrWrapper` loading
3. Creates `LoadAndConstructLoadWrapper` whose `serialize` method calls `Construct<T, Archive>::load_andor_construct`
4. Invokes `LoadAndConstruct<T>::load_and_construct(ar, construct)`

This was verified across multiple patterns:
- Types with only external `save` + external `LoadAndConstruct` (no serialize/load)
- Types with member `serialize` + external `LoadAndConstruct`
- Polymorphic types with `CEREAL_REGISTER_TYPE`
- Multiple data members (verifying binary stream positioning)
- Both `shared_ptr` and `unique_ptr`

The reported issue may be related to:
- The user's `LoadAndConstruct` specialization not being visible at the point of template instantiation
- A compiler-specific SFINAE evaluation difference
- Incorrect data read order in `load_and_construct` vs what was written by `save`/`serialize` (binary is positional)

## Changes

Added a comprehensive test (`unittests/load_construct_ext_binary.cpp`) that explicitly verifies external `LoadAndConstruct` works with all archive types including Binary. This serves as:
- Documentation of correct usage patterns
- Regression test to catch future breakage

## Test Results

All 41 tests pass (40 existing + 1 new):

[test_results_issue839.log](https://cursor.com/agents/bc-f60ec4d8-5a2a-4e23-b6f0-4da1e3ba76d9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftest_results_issue839.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f60ec4d8-5a2a-4e23-b6f0-4da1e3ba76d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f60ec4d8-5a2a-4e23-b6f0-4da1e3ba76d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

